### PR TITLE
Print most similar options when reporting unknown options

### DIFF
--- a/src/exceptions/UnknownOptionException.php
+++ b/src/exceptions/UnknownOptionException.php
@@ -9,18 +9,30 @@
  */
 namespace SebastianBergmann\CliParser;
 
+use function implode;
 use function sprintf;
 use RuntimeException;
 
 final class UnknownOptionException extends RuntimeException implements Exception
 {
-    public function __construct(string $option)
+    /**
+     * @param array<string> $similarOptions
+     */
+    public function __construct(string $option, array $similarOptions)
     {
-        parent::__construct(
-            sprintf(
-                'Unknown option "%s"',
-                $option,
-            ),
+        $message = sprintf(
+            'Unknown option "%s"',
+            $option,
         );
+
+        if ($similarOptions !== []) {
+            $message = sprintf(
+                'Unknown option "%s". Most similar options are %s',
+                $option,
+                implode(', ', $similarOptions),
+            );
+        }
+
+        parent::__construct($message);
     }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -213,7 +213,7 @@ final class ParserTest extends TestCase
     public function testRaisesAnExceptionForUnknownLongOption(): void
     {
         $this->expectException(UnknownOptionException::class);
-        $this->expectExceptionMessage('Unknown option "--foo"');
+        $this->expectExceptionMessage('Unknown option "--foo". Most similar options are --colors');
 
         (new Parser)->parse(
             [
@@ -222,6 +222,21 @@ final class ParserTest extends TestCase
             ],
             '',
             ['colors'],
+        );
+    }
+
+    public function testRaisesAnExceptionForUnknownLongOptionMultipleAlternatives(): void
+    {
+        $this->expectException(UnknownOptionException::class);
+        $this->expectExceptionMessage('Unknown option "--foo". Most similar options are --colors, --exec, --help, --config, --column');
+
+        (new Parser)->parse(
+            [
+                'command',
+                '--foo',
+            ],
+            '',
+            ['colors', 'columns', 'verbose', 'help', 'version', 'output', 'config', 'exec'],
         );
     }
 


### PR DESCRIPTION
Print the 5 most similar options on unknown option errors

before this PR
```
➜  phpunit git:(main) php phpunit --suite
PHPUnit 12.4-g0789a9a91 by Sebastian Bergmann and contributors.

Unknown option "--suite"
```

after this PR:
```
➜  phpunit git:(main) php phpunit --suite
PHPUnit 12.4-g0789a9a91 by Sebastian Bergmann and contributors.

Unknown option "--suite". Most similar options are --debug, --filter, --help, --stderr, --testsuite
```