### PR TITLE
phpdoc of parameter $longOptions in Parser::parse has an incomplete type hint

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -37,7 +37,7 @@ final readonly class Parser
 {
     /**
      * @param list<string> $argv
-     * @param list<string> $longOptions
+     * @param list<string>|null $longOptions
      *
      * @throws AmbiguousOptionException
      * @throws OptionDoesNotAllowArgumentException


### PR DESCRIPTION
Hallo Sebastian!

Maybe we should allow a `null` in the phpdoc, too.

> Implicitly marking parameter $longOptions as nullable is deprecated 

found on phpcpd 6.0.3, 06-Jul-2026 21:55:51 UTC

Grüße aus Berlin,
eurosat7
